### PR TITLE
Feat/consistent callback api

### DIFF
--- a/src/conduit/client/managers/callbacks.py
+++ b/src/conduit/client/managers/callbacks.py
@@ -139,8 +139,32 @@ class CallbackManager:
     def on_prompts_changed(
         self, callback: Callable[[list[Prompt]], Awaitable[None]]
     ) -> None:
-        """Register callback for when server prompts change."""
+        """Register your callback for when server prompts change.
+
+        Servers send a signal when their prompt catalog changes - prompts
+        added, removed, or modified. We automatically fetch the updated prompts
+        list and call your callback with the current prompts.
+
+        Args:
+            callback: Your async function called with the updated list[Prompt]
+                whenever the server's prompt catalog changes.
+        """
         self._prompts_changed = callback
+
+    async def call_prompts_changed(self, prompts: list[Prompt]) -> None:
+        """Invoke your registered prompts changed callback with the updated prompts.
+
+        Calls your prompts callback if you've registered one. Logs any errors
+        that occur.
+
+        Args:
+            prompts: Current prompts list to pass through to your callback.
+        """
+        if self._prompts_changed:
+            try:
+                await self._prompts_changed(prompts)
+            except Exception as e:
+                print(f"Prompts changed callback failed: {e}")
 
     def on_logging_message(
         self, callback: Callable[[LoggingMessageNotification], Awaitable[None]]
@@ -162,13 +186,6 @@ class CallbackManager:
                 await self._resource_updated(uri, result)
             except Exception as e:
                 print(f"Resource updated callback failed: {e}")
-
-    async def call_prompts_changed(self, prompts: list[Prompt]) -> None:
-        if self._prompts_changed:
-            try:
-                await self._prompts_changed(prompts)
-            except Exception as e:
-                print(f"Prompts changed callback failed: {e}")
 
     async def call_logging_message(
         self, notification: LoggingMessageNotification

--- a/src/conduit/client/managers/callbacks.py
+++ b/src/conduit/client/managers/callbacks.py
@@ -133,8 +133,34 @@ class CallbackManager:
     def on_resource_updated(
         self, callback: Callable[[str, ReadResourceResult], Awaitable[None]]
     ) -> None:
-        """Register callback for when server resource is updated."""
+        """Register your callback for when a specific resource is updated.
+
+        Servers send notifications when individual resources change. We
+        automatically read the updated resource content and call your callback
+        with both the resource URI and the fresh data.
+
+        Args:
+            callback: Your async function called with (uri, result) when a
+                resource is updated. Gets the resource URI string and
+                ReadResourceResult with the updated content.
+        """
         self._resource_updated = callback
+
+    async def call_resource_updated(self, uri: str, result: ReadResourceResult) -> None:
+        """Invoke your registered resource updated callback with URI and result.
+
+        Calls your resource updated callback if you've registered one. Logs any
+        errors that occur.
+
+        Args:
+            uri: Resource URI that was updated.
+            result: Fresh resource data from the server.
+        """
+        if self._resource_updated:
+            try:
+                await self._resource_updated(uri, result)
+            except Exception as e:
+                print(f"Resource updated callback failed: {e}")
 
     def on_prompts_changed(
         self, callback: Callable[[list[Prompt]], Awaitable[None]]
@@ -202,13 +228,6 @@ class CallbackManager:
                 print(f"Cancelled callback failed: {e}")
 
     # Internal notification methods
-
-    async def call_resource_updated(self, uri: str, result: ReadResourceResult) -> None:
-        if self._resource_updated:
-            try:
-                await self._resource_updated(uri, result)
-            except Exception as e:
-                print(f"Resource updated callback failed: {e}")
 
     async def call_logging_message(
         self, notification: LoggingMessageNotification

--- a/src/conduit/client/managers/callbacks.py
+++ b/src/conduit/client/managers/callbacks.py
@@ -41,8 +41,33 @@ class CallbackManager:
     def on_progress(
         self, callback: Callable[[ProgressNotification], Awaitable[None]]
     ) -> None:
-        """Register callback for progress notifications."""
+        """Register your callback for server progress updates.
+
+        Your callback receives the complete notification with all progress
+        details - current amount, total expected, status messages, and the
+        token identifying which operation is progressing.
+
+        Args:
+            callback: Your async function called with each ProgressNotification.
+                Gets progress_token, progress, total (optional), and message
+                (optional) fields.
+        """
         self._progress = callback
+
+    async def call_progress(self, notification: ProgressNotification) -> None:
+        """Invoke your registered progress callback with the notification.
+
+        Calls your progress callback if you've registered one. Logs any errors
+        that occur.
+
+        Args:
+            notification: Progress notification to pass through to your callback.
+        """
+        if self._progress:
+            try:
+                await self._progress(notification)
+            except Exception as e:
+                print(f"Progress callback failed: {e}")
 
     def on_tools_changed(
         self, callback: Callable[[list[Tool]], Awaitable[None]]
@@ -87,12 +112,6 @@ class CallbackManager:
         self._cancelled = callback
 
     # Internal notification methods
-    async def call_progress(self, notification: ProgressNotification) -> None:
-        if self._progress:
-            try:
-                await self._progress(notification)
-            except Exception as e:
-                print(f"Progress callback failed: {e}")
 
     async def call_tools_changed(self, tools: list[Tool]) -> None:
         if self._tools_changed:

--- a/src/conduit/client/managers/callbacks.py
+++ b/src/conduit/client/managers/callbacks.py
@@ -72,8 +72,32 @@ class CallbackManager:
     def on_tools_changed(
         self, callback: Callable[[list[Tool]], Awaitable[None]]
     ) -> None:
-        """Register callback for when server tools change."""
+        """Register your callback for when server tools change.
+
+        Servers send a signal when their tool catalog changes - tools added,
+        removed, or modified. We automatically fetch the updated list and
+        call your callback with the new list.
+
+        Args:
+            callback: Your async function called with the new list of tools
+                whenever the server's tool catalog changes.
+        """
         self._tools_changed = callback
+
+    async def call_tools_changed(self, tools: list[Tool]) -> None:
+        """Invoke your registered tools changed callback with the updated tools.
+
+        Calls your tools callback if you've registered one. Logs any errors
+        that occur.
+
+        Args:
+            tools: Current tools list to pass through to your callback.
+        """
+        if self._tools_changed:
+            try:
+                await self._tools_changed(tools)
+            except Exception as e:
+                print(f"Tools changed callback failed: {e}")
 
     def on_resources_changed(
         self, callback: Callable[[list[Resource]], Awaitable[None]]
@@ -112,13 +136,6 @@ class CallbackManager:
         self._cancelled = callback
 
     # Internal notification methods
-
-    async def call_tools_changed(self, tools: list[Tool]) -> None:
-        if self._tools_changed:
-            try:
-                await self._tools_changed(tools)
-            except Exception as e:
-                print(f"Tools changed callback failed: {e}")
 
     async def call_resources_changed(self, resources: list[Resource]) -> None:
         if self._resources_changed:

--- a/src/conduit/client/managers/callbacks.py
+++ b/src/conduit/client/managers/callbacks.py
@@ -195,8 +195,34 @@ class CallbackManager:
     def on_logging_message(
         self, callback: Callable[[LoggingMessageNotification], Awaitable[None]]
     ) -> None:
-        """Register callback for server logging messages."""
+        """Register your callback for server logging messages.
+
+        Servers send log messages during operations to provide debugging
+        information and status updates. Your callback receives the complete
+        notification with all logging details.
+
+        Args:
+            callback: Your async function called with each LoggingMessageNotification.
+                Gets level, data, and logger (optional) fields.
+        """
         self._logging_message = callback
+
+    async def call_logging_message(
+        self, notification: LoggingMessageNotification
+    ) -> None:
+        """Invoke your registered logging message callback with the notification.
+
+        Calls your logging callback if you've registered one. Logs any errors
+        that occur.
+
+        Args:
+            notification: Logging notification to pass through to your callback.
+        """
+        if self._logging_message:
+            try:
+                await self._logging_message(notification)
+            except Exception as e:
+                print(f"Logging message callback failed: {e}")
 
     def on_cancelled(
         self, callback: Callable[[CancelledNotification], Awaitable[None]]
@@ -228,12 +254,3 @@ class CallbackManager:
                 print(f"Cancelled callback failed: {e}")
 
     # Internal notification methods
-
-    async def call_logging_message(
-        self, notification: LoggingMessageNotification
-    ) -> None:
-        if self._logging_message:
-            try:
-                await self._logging_message(notification)
-            except Exception as e:
-                print(f"Logging message callback failed: {e}")

--- a/src/conduit/client/managers/callbacks.py
+++ b/src/conduit/client/managers/callbacks.py
@@ -175,8 +175,31 @@ class CallbackManager:
     def on_cancelled(
         self, callback: Callable[[CancelledNotification], Awaitable[None]]
     ) -> None:
-        """Register callback for when server cancels a request."""
+        """Register your callback for when server cancels a request.
+
+        Your callback receives the complete notification with
+        cancellation details - which request was cancelled and why.
+
+        Args:
+            callback: Your async function called with each CancelledNotification.
+                Gets request_id and reason (optional) fields.
+        """
         self._cancelled = callback
+
+    async def call_cancelled(self, notification: CancelledNotification) -> None:
+        """Invoke your registered cancelled callback with the notification.
+
+        Calls your cancelled callback if you've registered one. Logs any errors
+        that occur.
+
+        Args:
+            notification: Cancellation notification to pass through to your callback.
+        """
+        if self._cancelled:
+            try:
+                await self._cancelled(notification)
+            except Exception as e:
+                print(f"Cancelled callback failed: {e}")
 
     # Internal notification methods
 
@@ -195,10 +218,3 @@ class CallbackManager:
                 await self._logging_message(notification)
             except Exception as e:
                 print(f"Logging message callback failed: {e}")
-
-    async def call_cancelled(self, notification: CancelledNotification) -> None:
-        if self._cancelled:
-            try:
-                await self._cancelled(notification)
-            except Exception as e:
-                print(f"Cancelled callback failed: {e}")

--- a/src/conduit/client/session.py
+++ b/src/conduit/client/session.py
@@ -424,7 +424,7 @@ class ClientSession(BaseSession):
     async def _handle_cancelled(self, notification: CancelledNotification) -> None:
         """Handle server cancellation notifications for in-flight requests.
 
-        Cancels the corresponding request task if it exists and notifies the
+        Cancels the corresponding request task if it exists and calls the
         registered callback. Only processes cancellations for requests that
         are actually in-flight.
 

--- a/src/conduit/client/session.py
+++ b/src/conduit/client/session.py
@@ -479,34 +479,39 @@ class ClientSession(BaseSession):
     ) -> None:
         """Handle server notification that the resources list has changed.
 
-        Fetches the updated resources and resource templates lists from the server,
-        updates local server state, and calls the registered callbacks with the
-        new data.
+        Fetches both the updated resources and resource templates from the server,
+        updates local server state for successful requests, and calls the registered
+        callback if at least one request succeeds.
 
         Args:
             notification: Notification that resources list has changed
                 (content ignored).
 
         Note:
-            Updates state and calls callbacks independently for resources and templates.
-            If one request fails, the other may still succeed. Failed requests are
-            silently ignored to avoid disrupting the session.
+            Calls the callback when at least one request succeeds, passing empty
+            lists for failed requests. If both requests fail, no callback is made.
         """
+        resources: list[Resource] = []
+        templates: list[ResourceTemplate] = []
+
         try:
             resources_result = await self.send_request(ListResourcesRequest())
-            templates_result = await self.send_request(ListResourceTemplatesRequest())
             if isinstance(resources_result, ListResourcesResult):
-                self.server_state.resources = resources_result.resources
-                await self.callbacks.call_resources_changed(resources_result.resources)
-            if isinstance(templates_result, ListResourceTemplatesResult):
-                self.server_state.resource_templates = (
-                    templates_result.resource_templates
-                )
-                await self.callbacks.call_resource_templates_changed(
-                    templates_result.resource_templates
-                )
+                resources = resources_result.resources
+                self.server_state.resources = resources
         except Exception:
             pass
+
+        try:
+            templates_result = await self.send_request(ListResourceTemplatesRequest())
+            if isinstance(templates_result, ListResourceTemplatesResult):
+                templates = templates_result.resource_templates
+                self.server_state.resource_templates = templates
+        except Exception:
+            pass
+
+        if resources or templates:
+            await self.callbacks.call_resources_changed(resources, templates)
 
     async def _handle_resources_updated(
         self, notification: ResourceUpdatedNotification

--- a/src/conduit/client/session.py
+++ b/src/conduit/client/session.py
@@ -526,7 +526,7 @@ class ClientSession(BaseSession):
 
         Note:
             Only calls callback if the resource read succeeds. Failed requests
-            are silently ignored to avoid disrupting the session.
+            are silently ignored.
         """
         try:
             result = await self.send_request(ReadResourceRequest(uri=notification.uri))

--- a/tests/client/managers/test_client_callback_manager.py
+++ b/tests/client/managers/test_client_callback_manager.py
@@ -30,13 +30,10 @@ class TestClientCallbackManager:
                 "resources_changed",
                 "on_resources_changed",
                 "call_resources_changed",
-                [Resource(name="test", uri="test://hi.txt")],
-            ),
-            (
-                "resource_templates_changed",
-                "on_resource_templates_changed",
-                "call_resource_templates_changed",
-                [ResourceTemplate(name="test", uri_template="test://{id}")],
+                [
+                    [Resource(name="test", uri="test://hi.txt")],
+                    [ResourceTemplate(name="test", uri_template="test://{id}")],
+                ],
             ),
             (
                 "prompts_changed",
@@ -66,11 +63,13 @@ class TestClientCallbackManager:
         callback = AsyncMock()
         getattr(manager, register_method)(callback)
 
-        # Act
-        await getattr(manager, notify_method)(test_data)
-
-        # Assert
-        callback.assert_awaited_once_with(test_data)
+        # Act & Assert
+        if callback_type == "resources_changed":
+            await getattr(manager, notify_method)(*test_data)
+            callback.assert_awaited_once_with(*test_data)
+        else:
+            await getattr(manager, notify_method)(test_data)
+            callback.assert_awaited_once_with(test_data)
 
     @pytest.mark.parametrize(
         "callback_type,notify_method,test_data",
@@ -88,12 +87,10 @@ class TestClientCallbackManager:
             (
                 "resources_changed",
                 "call_resources_changed",
-                [Resource(name="test", uri="test://hi.txt")],
-            ),
-            (
-                "resource_templates_changed",
-                "call_resource_templates_changed",
-                [ResourceTemplate(name="test", uri_template="test://{id}")],
+                [
+                    [Resource(name="test", uri="test://hi.txt")],
+                    [ResourceTemplate(name="test", uri_template="test://{id}")],
+                ],
             ),
             ("prompts_changed", "call_prompts_changed", [Prompt(name="test")]),
             (
@@ -115,4 +112,7 @@ class TestClientCallbackManager:
         manager = CallbackManager()
 
         # Act & Assert (should not raise)
-        await getattr(manager, notify_method)(test_data)
+        if callback_type == "resources_changed":
+            await getattr(manager, notify_method)(*test_data)
+        else:
+            await getattr(manager, notify_method)(test_data)


### PR DESCRIPTION
# Fix callback API consistency and improve documentation

## Problem
Our notification callback API was inconsistent and unpredictable. Users couldn't tell what parameters their callback functions should accept just by looking at the registration method, leading to poor developer experience.

**Examples of the inconsistency:**
```python
# Sometimes you get the actual data:
session.callbacks.on_tools_changed(lambda tools: ...)

# Sometimes you get the raw notification:
session.callbacks.on_progress(lambda notification: ...)

# Sometimes you get custom parameters:
session.callbacks.on_resource_updated(lambda uri, result: ...)
```

## Solution
Established two clear, semantic patterns based on MCP notification types:

### Data-Carrying Notifications
Pass the complete notification object containing meaningful data:
- `on_progress(ProgressNotification)` - progress updates with current/total/message
- `on_cancelled(CancelledNotification)` - cancellation with request_id/reason  
- `on_logging_message(LoggingMessageNotification)` - log messages with level/data

### Signal Notifications  
Fetch current state and pass the actual data users need:
- `on_tools_changed(list[Tool])` - fetched tools after catalog change signal
- `on_resources_changed(list[Resource], list[ResourceTemplate])` - fetched resources/templates
- `on_prompts_changed(list[Prompt])` - fetched prompts after catalog change
- `on_resource_updated(str, ReadResourceResult)` - URI + fetched content for subscribed resources

## Key Improvements
- **Predictable API** - callback signatures are discoverable and follow clear patterns
- **Consistent documentation** - all callbacks use "your" voice and explain what users receive
- **Maximum robustness** - resources callback handles partial failures gracefully
- **Fixed bug** - removed dead code for resource templates (no separate notification exists)
- **Better error boundaries** - protocol errors vs user callback errors handled appropriately

## Impact
Developers can now predict callback behavior from registration method signatures. The API teaches users how to think about MCP notifications rather than requiring memorization of arbitrary patterns.

Addresses server half of #1 