### PR TITLE
Manager API consistency

### DIFF
--- a/tests/server/managers/test_logging_manager.py
+++ b/tests/server/managers/test_logging_manager.py
@@ -24,7 +24,7 @@ class TestLoggingManager:
         # Arrange
         manager = LoggingManager()
         callback = AsyncMock()
-        manager.set_handler(callback)
+        manager.on_level_change(callback)
         request = SetLevelRequest(level="warning")
 
         # Act

--- a/tests/server/managers/test_resource_manager.py
+++ b/tests/server/managers/test_resource_manager.py
@@ -27,11 +27,11 @@ class TestResourceManager:
         handler = AsyncMock()
 
         # Act
-        manager.register_resource(resource, handler)
+        manager.register(resource, handler)
 
         # Assert
-        assert "file://test.txt" in manager.registered
-        assert manager.registered["file://test.txt"] is resource
+        assert "file://test.txt" in manager.registered_resources
+        assert manager.registered_resources["file://test.txt"] is resource
         assert "file://test.txt" in manager.handlers
         assert manager.handlers["file://test.txt"] is handler
 
@@ -44,11 +44,11 @@ class TestResourceManager:
         handler = AsyncMock()
 
         # Act
-        manager.register_template(template, handler)
+        manager.register(template, handler)
 
         # Assert
-        assert "file://logs/{date}.log" in manager.templates
-        assert manager.templates["file://logs/{date}.log"] is template
+        assert "file://logs/{date}.log" in manager.registered_templates
+        assert manager.registered_templates["file://logs/{date}.log"] is template
         assert "file://logs/{date}.log" in manager.template_handlers
         assert manager.template_handlers["file://logs/{date}.log"] is handler
 
@@ -57,7 +57,7 @@ class TestResourceManager:
         manager = ResourceManager()
         resource = Resource(uri="file://test.txt", name="Test File")
         handler = AsyncMock()
-        manager.register_resource(resource, handler)
+        manager.register(resource, handler)
         request = ListResourcesRequest()
 
         # Act
@@ -73,7 +73,7 @@ class TestResourceManager:
             uri_template="file://logs/{date}.log", name="Log Files"
         )
         handler = AsyncMock()
-        manager.register_template(template, handler)
+        manager.register(template, handler)
         request = ListResourceTemplatesRequest()
 
         # Act
@@ -90,7 +90,7 @@ class TestResourceManager:
             contents=[TextResourceContents(uri="file://test.txt", text="file content")]
         )
         handler = AsyncMock(return_value=expected_result)
-        manager.register_resource(resource, handler)
+        manager.register(resource, handler)
         request = ReadResourceRequest(uri="file://test.txt")
 
         # Act
@@ -114,7 +114,7 @@ class TestResourceManager:
         manager = ResourceManager()
         resource = Resource(uri="file://test.txt", name="Test File")
         handler = AsyncMock()
-        manager.register_resource(resource, handler)
+        manager.register(resource, handler)
         request = SubscribeRequest(uri="file://test.txt")
 
         # Act
@@ -130,8 +130,8 @@ class TestResourceManager:
         resource = Resource(uri="file://test.txt", name="Test File")
         handler = AsyncMock()
         callback = AsyncMock()
-        manager.register_resource(resource, handler)
-        manager.on_subscribe = callback
+        manager.register(resource, handler)
+        manager._on_subscribe = callback
         request = SubscribeRequest(uri="file://test.txt")
 
         # Act
@@ -156,7 +156,7 @@ class TestResourceManager:
         manager = ResourceManager()
         resource = Resource(uri="file://test.txt", name="Test File")
         handler = AsyncMock()
-        manager.register_resource(resource, handler)
+        manager.register(resource, handler)
         manager.subscriptions.add("file://test.txt")
         request = UnsubscribeRequest(uri="file://test.txt")
 
@@ -172,7 +172,7 @@ class TestResourceManager:
         manager = ResourceManager()
         callback = AsyncMock()
         manager.subscriptions.add("file://test.txt")
-        manager.on_unsubscribe = callback
+        manager._on_unsubscribe = callback
         request = UnsubscribeRequest(uri="file://test.txt")
 
         # Act
@@ -208,7 +208,7 @@ class TestResourceManager:
             ]
         )
         handler = AsyncMock(return_value=expected_result)
-        manager.register_template(template, handler)
+        manager.register(template, handler)
         request = ReadResourceRequest(uri="file://logs/2024-01-15.log")
 
         # Act
@@ -226,8 +226,8 @@ class TestResourceManager:
         )
         handler = AsyncMock()
         callback = AsyncMock()
-        manager.register_template(template, handler)
-        manager.on_subscribe = callback
+        manager.register(template, handler)
+        manager._on_subscribe = callback
         request = SubscribeRequest(uri="file://logs/2024-01-15.log")
 
         # Act

--- a/tests/server/session/test_logging_handling.py
+++ b/tests/server/session/test_logging_handling.py
@@ -54,7 +54,7 @@ class TestSetLevel(ServerSessionTest):
 
         # Set up a failing callback
         failing_callback = AsyncMock(side_effect=ValueError("Callback failed"))
-        self.session.logging.on_level_change = failing_callback
+        self.session.logging.on_level_change(failing_callback)
 
         request = SetLevelRequest(level="info")
 


### PR DESCRIPTION
## What changed?

Standardized manager APIs across the codebase to create consistent patterns:

- **ResourceManager**: Unified `register_resource()` and `register_template()` into single `register()` method that handles both Resource and ResourceTemplate objects
- **ResourceManager**: Converted direct callback assignment to `on_subscribe()` and `on_unsubscribe()` methods
- **LoggingManager**: Aligned with event callback pattern using `on_level_change()` method
- Made all callback attributes private (`_on_subscribe`, `_on_unsubscribe`, `_on_level_change`)
- Updated internal attribute names for clarity (`registered` → `registered_resources`, `templates` → `registered_templates`)

## Why?

Our manager APIs had four different paradigms creating an unpredictable surface:
1. Per-item registration (tools)
2. Global handler registration (completions) 
3. Callback registration (callbacks)
4. Direct assignment (resources)

This forced developers to learn different patterns for each manager, reducing API predictability and delight.

## Impact

Creates three consistent semantic patterns:
- **Items with handlers** → `register(item, handler)` - for concrete items like tools and resources
- **Global capabilities** → `set_handler(handler)` - for capabilities you implement like completions
- **Event callbacks** → `on_*(callback)` - for events you react to like initialization and log level changes

Developers can now use the same mental model across all managers, significantly reducing cognitive overhead and improving API predictability.

## Testing

- Updated all existing tests to match new method signatures
- All ResourceManager tests pass with unified `register()` method
- All LoggingManager tests pass with `on_level_change()` pattern
- Verified type safety with isinstance() checks in unified registration

## Review notes

Pay special attention to:
- The semantic distinction between "you implement this" vs "you react to this" in the API design
- Type safety in the unified `register()` method using isinstance() checks
- Consistent private attribute naming across managers

## Checklist

- [x] All new and old tests pass
- [x] Code follows our style guidelines
- [x] Documentation updated if needed
- [x] Breaking changes documented in commit messages

Closes #7 