### PR TITLE
feat: use boolean capabilities for logging and completions

### DIFF
--- a/src/conduit/server/session.py
+++ b/src/conduit/server/session.py
@@ -443,7 +443,7 @@ class ServerSession(BaseSession):
             Error: If completions capability not supported, handler not configured,
                 or generation fails.
         """
-        if self.server_config.capabilities.completions is None:
+        if not self.server_config.capabilities.completions:
             return Error(
                 code=METHOD_NOT_FOUND,
                 message="Server does not support completion capability",
@@ -480,7 +480,7 @@ class ServerSession(BaseSession):
             EmptyResult: Level set successfully.
             Error: If logging capability not supported.
         """
-        if self.server_config.capabilities.logging is None:
+        if not self.server_config.capabilities.logging:
             return Error(
                 code=METHOD_NOT_FOUND,
                 message="Server does not support logging capability",

--- a/tests/protocol/test_jsonrpc.py
+++ b/tests/protocol/test_jsonrpc.py
@@ -77,7 +77,7 @@ class TestJSONRPCSerializing:
 
     def test_serializes_response_with_params(self):
         result = InitializeResult(
-            capabilities=ServerCapabilities(completions={}),
+            capabilities=ServerCapabilities(completions=True),
             server_info=Implementation(name="test server", version="1"),
             instructions="Use me well",
         )

--- a/tests/server/session/test_completion_handling.py
+++ b/tests/server/session/test_completion_handling.py
@@ -17,7 +17,7 @@ class TestComplete(ServerSessionTest):
     async def test_returns_result_from_manager_when_capability_enabled(self):
         """Test successful completion when completions capability is enabled."""
         # Arrange
-        self.config.capabilities.completions = {}  # Enable completions
+        self.config.capabilities.completions = True  # Enable completions
 
         completion = Completion(
             values=["python", "pytest"],
@@ -49,7 +49,7 @@ class TestComplete(ServerSessionTest):
     async def test_rejects_complete_when_capability_not_set(self):
         """Test error when completions capability is not configured."""
         # Arrange
-        self.config.capabilities.completions = None  # No completions capability
+        self.config.capabilities.completions = False  # No completions capability
         request = CompleteRequest(
             ref=PromptReference(name="test_prompt"),
             argument=CompletionArgument(name="language", value="py"),
@@ -66,7 +66,7 @@ class TestComplete(ServerSessionTest):
     async def test_returns_method_not_found_when_handler_not_configured(self):
         """Test error when manager raises CompletionNotConfiguredError."""
         # Arrange
-        self.config.capabilities.completions = {}  # Enable capability
+        self.config.capabilities.completions = True  # Enable capability
 
         # Mock the manager to raise CompletionNotConfiguredError
         self.session.completions.handle_complete = AsyncMock(
@@ -92,7 +92,7 @@ class TestComplete(ServerSessionTest):
     async def test_returns_internal_error_when_manager_raises_exception(self):
         """Test error when manager raises unexpected exception."""
         # Arrange
-        self.config.capabilities.completions = {}  # Enable capability
+        self.config.capabilities.completions = True  # Enable capability
 
         # Mock the manager to raise generic exception
         self.session.completions.handle_complete = AsyncMock(

--- a/tests/server/session/test_logging_handling.py
+++ b/tests/server/session/test_logging_handling.py
@@ -11,7 +11,7 @@ class TestSetLevel(ServerSessionTest):
     async def test_sets_level_when_capability_enabled(self):
         """Test successful log level setting when logging capability is enabled."""
         # Arrange
-        self.config.capabilities.logging = {}  # Enable logging
+        self.config.capabilities.logging = True  # Enable logging
 
         # Mock the manager to return success
         self.session.logging.handle_set_level = AsyncMock(return_value=EmptyResult())
@@ -30,7 +30,7 @@ class TestSetLevel(ServerSessionTest):
     async def test_rejects_set_level_when_capability_not_set(self):
         """Test error when logging capability is not configured."""
         # Arrange
-        self.config.capabilities.logging = None  # No logging capability
+        self.config.capabilities.logging = False  # No logging capability
         request = SetLevelRequest(level="debug")
 
         # Act
@@ -49,7 +49,7 @@ class TestSetLevel(ServerSessionTest):
         succeeds.
         """
         # Arrange
-        self.config.capabilities.logging = {}  # Enable capability
+        self.config.capabilities.logging = True  # Enable capability
         assert self.session.logging.current_level is None
 
         # Set up a failing callback


### PR DESCRIPTION
## What changed?

Convert logging and completions server capabilities from dict|None to boolean pattern, matching client capabilities design.

- Update ServerCapabilities to use bool fields with False defaults
- Add from_protocol/to_protocol methods to InitializeResult for wire format conversion
- Update session capability checks to use boolean semantics
- Add comprehensive tests for wire format serialization/deserialization
- Fix tests to use boolean capabilities

## Why?

API is now consistent with the client capabilities.

## Impact

This creates a more Pythonic API while maintaining MCP wire compatibility.

## Testing

Added new initialize result round trip tests.

## Review notes

N/A

## Checklist

- [x] All new and old tests pass
- [x] Code follows our style guidelines
- [x] Documentation updated if needed
- [x] Breaking changes documented in commit messages


