### PR TITLE
test: add comprehensive response parsing tests

### DIFF
--- a/src/conduit/shared/session.py
+++ b/src/conduit/shared/session.py
@@ -212,7 +212,6 @@ class BaseSession(ABC):
         else:
             print(f"Unmatched response for request ID {message_id}")
 
-    # TODO: TEST THIS
     def _parse_response(
         self, payload: dict[str, Any], original_request: Request
     ) -> Result | Error:


### PR DESCRIPTION
## What changed?

Added focused tests for the _parse_response method in shared session to verify both happy paths (result/error parsing) and failure modes.

Closes #2 

## Why?

These tests isolate the parsing logic from the broader request/response lifecycle, ensuring robust error handling and diagnostic information.

## Impact

Improves confidence in response parsing and provides better test coverage for edge cases like malformed responses and parsing failures. The tests verify that parsing errors are converted into structured Error objects with helpful diagnostic data.

## Testing

Test specific PR.

## Review notes

N/A

## Checklist

- [x] All new and old tests pass
- [x] Code follows our style guidelines
- [x] Documentation updated if needed
- [x] Breaking changes documented in commit messages

---

*Thanks for contributing to conduit-mcp! 🚀*
