### PR TITLE
Feat/server transport interface

### DIFF
--- a/src/conduit/transport/http/server/message_sender.py
+++ b/src/conduit/transport/http/server/message_sender.py
@@ -5,7 +5,7 @@ from typing import Any
 from conduit.transport.http.server.connection_manager import ConnectionManager
 
 
-class ServerMessageSender:
+class MessageSender:
     """Handles outbound messages from server to specific clients.
 
     Manages the server's side of HTTP communication:

--- a/src/conduit/transport/http/server/stream_manager.py
+++ b/src/conduit/transport/http/server/stream_manager.py
@@ -5,7 +5,7 @@ from typing import Any
 from conduit.transport.http.server.connection_manager import ConnectionManager
 
 
-class ServerStreamManager:
+class StreamManager:
     """Manages outbound SSE streams TO multiple clients.
 
     Handles server → client message delivery via SSE streams:

--- a/src/conduit/transport/server.py
+++ b/src/conduit/transport/server.py
@@ -1,0 +1,78 @@
+"""Server transport protocol - 1:many communication with clients."""
+
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Protocol
+
+
+@dataclass
+class ClientMessage:
+    """Message from a client with explicit connection context."""
+
+    client_id: str
+    payload: dict[str, Any]
+    timestamp: float
+    metadata: dict[str, Any] | None = None
+
+
+class ServerTransport(Protocol):
+    """Transport for server communicating with multiple clients.
+
+    Handles the 1:many connection pattern where one server needs to
+    communicate with multiple clients simultaneously.
+    """
+
+    async def send_to_client(self, client_id: str, message: dict[str, Any]) -> None:
+        """Send message to specific client.
+
+        Args:
+            client_id: Target client session ID
+            message: JSON-RPC message to send
+
+        Raises:
+            ValueError: If client_id is not an active session
+        """
+        ...
+
+    async def broadcast(
+        self, message: dict[str, Any], exclude: set[str] | None = None
+    ) -> None:
+        """Send message to all connected clients.
+
+        Args:
+            message: JSON-RPC message to broadcast
+            exclude: Optional set of client IDs to exclude from broadcast
+        """
+        ...
+
+    def client_messages(self) -> AsyncIterator[ClientMessage]:
+        """Stream of messages from all clients with explicit client context.
+
+        Yields:
+            ClientMessage: Message with client ID and metadata
+        """
+        ...
+
+    def active_clients(self) -> set[str]:
+        """Get currently connected client IDs.
+
+        Returns:
+            Set of active client session IDs
+        """
+        ...
+
+    async def disconnect_client(self, client_id: str) -> None:
+        """Disconnect specific client.
+
+        Args:
+            client_id: Client session ID to disconnect
+        """
+        ...
+
+    @property
+    def is_open(self) -> bool:
+        """True if server is open and accepting connections."""
+        ...
+
+    async def close(self) -> None:
+        """Close server and disconnect all clients."""
+        ...


### PR DESCRIPTION
## What changed?

Introduced new server transport abstraction. Stubbed out a streamable http implementation.

## Why?

MCP servers are 1:many while clients are 1:1. We didn't appreciate that difference before and tried to force them to use the same transport interface. We were limited by the unified interface and had to hack around the design to make the server fit. Now, we have a specific, multi-client oriented, interface for servers.

## Impact

The server-specific transport interface sets the stage for a natural feeling server session that can handle as many simultaneous client connections as we like.


## Testing

None

## Review notes

N/A

## Checklist

- [x] All new and old tests pass
- [x] Code follows our style guidelines
- [x] Documentation updated if needed
- [x] Breaking changes documented in commit messages

---

*Thanks for contributing to conduit-mcp! 🚀*
